### PR TITLE
Update rotor-http to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,11 +5,9 @@ dependencies = [
  "clap 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-type 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rotor 0.4.0 (git+git://github.com/tailhook/rotor?rev=4c142d4)",
- "rotor-http 0.4.0 (git+git://github.com/tailhook/rotor-http?rev=a855cdaab)",
- "rotor-stream 0.3.0 (git+git://github.com/tailhook/rotor-stream?rev=2628e69)",
+ "rotor 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rotor-http 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -331,8 +329,8 @@ dependencies = [
 
 [[package]]
 name = "rotor"
-version = "0.4.0"
-source = "git+git://github.com/tailhook/rotor?rev=4c142d4#4c142d4725d9aca7af9611116746bd372b166cbc"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -340,8 +338,8 @@ dependencies = [
 
 [[package]]
 name = "rotor-http"
-version = "0.4.0"
-source = "git+git://github.com/tailhook/rotor-http?rev=a855cdaab#a855cdaabd0b5f4ee946cb039d51d82abec7eb96"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "httparse 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -349,20 +347,21 @@ dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rotor 0.4.0 (git+git://github.com/tailhook/rotor?rev=4c142d4)",
- "rotor-stream 0.3.0 (git+git://github.com/tailhook/rotor-stream?rev=2628e69)",
+ "rotor 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rotor-stream 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rotor-stream"
-version = "0.3.0"
-source = "git+git://github.com/tailhook/rotor-stream?rev=2628e69#2628e6996592bb567f69e3ef623cc07fc5fbddde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "netbuf 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rotor 0.4.0 (git+git://github.com/tailhook/rotor?rev=4c142d4)",
+ "rotor 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,8 @@ authors = ["Brian Anderson <banderson@mozilla.com>"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-rotor = {git="git://github.com/tailhook/rotor", rev="4c142d4"}
-rotor-stream = {git="git://github.com/tailhook/rotor-stream", rev="2628e69"}
-rotor-http = {git="git://github.com/tailhook/rotor-http", rev="a855cdaab"}
-mio = "0.5"
+rotor = "0.5.1"
+rotor-http = "0.5.0"
 time = "0.1"
 clap = "1.5.5"
 threadpool = "0.2.1"


### PR DESCRIPTION
Just quick update to rotor-http 0.5

This version can be tested with apache benchmark (`ab`) but not in keep-alive mode (I mean it works but doesn't give any improvements). It turns out ab pretends to be HTTP/1.0 with `Connection: Keep-Alive`. I believe there are not that much HTTP/1.0 servers in the wild in 2016 to support that mode.