### PR TITLE
Print out http:// before URL.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn parse_config_from_cmdline() -> Result<Config, Error> {
     };
 
     // Display the configuration to be helpful
-    println!("addr: {}", addr);
+    println!("addr: http://{}", addr);
     println!("root dir: {:?}", root_dir);
     println!("server threads: {}", num_server_threads);
     println!("file threads: {}", num_file_threads);


### PR DESCRIPTION
```
$ basic-http-server
addr: http://127.0.0.1:4000
root dir: "."
server threads: 4
file threads: 100

listening on 127.0.0.1:4000
listening on 127.0.0.1:4000
listening on 127.0.0.1:4000
listening on 127.0.0.1:4000
```

This allows me to command+click from my terminal easily.

Could also add this e.g. in the threads dump, or in a new "URL" line.