### PR TITLE
Add Access-Control-Allow-Origin header to file response

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,7 @@ async fn respond_with_file(path: PathBuf) -> Result<Response<Body>> {
         .status(StatusCode::OK)
         .header(header::CONTENT_LENGTH, len as u64)
         .header(header::CONTENT_TYPE, mime_type.as_ref())
+        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .body(body)?;
 
     Ok(resp)


### PR DESCRIPTION
This would be nice for e.g. serving wasm.
If this header is missing, you will get
```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://127.0.0.1:4000/file.wasm. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).
```